### PR TITLE
Custom command fix

### DIFF
--- a/lib/denonCommands.js
+++ b/lib/denonCommands.js
@@ -44,7 +44,9 @@ module.exports = (cli, denon) => {
         dolby, dts, rock, jazz.`))
     .action(args => denon.command(`MS${args.type ? getSurroundMode(args.type) : '?'}`));
 
-  cli.command('command <cmd>', 'Custom command.')
+  cli.command('command <cmd> [opt...]', 'Custom command.')
     .alias('c')
-    .action(args => denon.command(args.cmd))
+    .action(args => denon.command(
+      Array.isArray(args.opt) ? [args.cmd, ...args.opt].join(' ') : args.cmd)
+    );
 };


### PR DESCRIPTION
It uses required argument and variadic arguments of vorpal's command option.
This should fix the custom command issue #10.